### PR TITLE
bump to vips v8.8.0

### DIFF
--- a/lib/vips/version.rb
+++ b/lib/vips/version.rb
@@ -1,4 +1,4 @@
 
 module Vips
-	VERSION = "8.7.0.1"
+	VERSION = "8.8.0"
 end


### PR DESCRIPTION
vips 8.8.0 was released a few days ago. This change simply changes the version number so this gem is using the latest stable version of vips (8.8.0)