### PR TITLE
Fixes redirect issue

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -8,9 +8,9 @@ prefix = ENV['PREFIX'] || File.dirname(__dir__)
 
 task :fetch do
 	url = "https://github.com/libvips/libvips/releases/download/v#{version}/#{archive_path}"
-	
+
 	unless File.exist? archive_path
-		sh "wget #{url}"
+		sh "wget #{url} -O #{archive_path}"
 	end
 end
 


### PR DESCRIPTION
Something's changed in the way that GitHub hosts the release files, and the download is redirected to a fingerprinted url (`aa4db900-d8a3-11e9-860e-638909f8a077?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20191217%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20191217T055736Z&X-Amz-Expires=300&X-Amz-Signature=d813bf723b5c67b10b68261` in the case of vips-8.8.3) and wget saves it with that filename, at least on mac. This one-line change forces the filename into what we expect it to be.